### PR TITLE
make an extra shutdown check in the listen routine

### DIFF
--- a/electrum/network.go
+++ b/electrum/network.go
@@ -232,6 +232,9 @@ type response struct {
 
 func (s *Server) listen() {
 	for {
+		if s.IsShutdown() {
+			break
+		}
 		if s.transport == nil {
 			break
 		}


### PR DESCRIPTION
We've been seeing intermittent crashes related to the inability to shutdown in a clean way when reaping stale ElectrumX connections.

Sample log output:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x134fd57]

goroutine 102 [running]:
github.com/thomasstevens89/go-electrum/electrum.(*Server).listen(0xc0007e47e0)
	/Users/vladimirli/.go/src/github.com/thomasstevens89/go-electrum/electrum/network.go:244 +0x87
created by github.com/thomasstevens89/go-electrum/electrum.(*Server).ConnectSSL
	/Users/vladimirli/.go/src/github.com/thomasstevens89/go-electrum/electrum/network.go:213 +0xab
make: *** [run] Error 2
```